### PR TITLE
Updated for jquery 1.8 selectors

### DIFF
--- a/jquery.xmlns.js
+++ b/jquery.xmlns.js
@@ -64,6 +64,7 @@
 
 (function($) {
 
+var jquery_gt_18 = jQuery.fn.jquery >= "1.8";
 //  Some common default namespaces, that are treated specially by browsers.
 //
 var default_xmlns = {
@@ -163,21 +164,25 @@ var getNamespaceURI = function(id) {
 //
 //  This logic is taken straight from the jQuery/Sizzle sources.
 //
-var setExprMatchRegex = function(type,regex) {
-  $.expr.match[type] = new RegExp(regex.source + /(?![^\[]*\])(?![^\(]*\))/.source);
-  if($.expr.leftMatch) {
-      $.expr.leftMatch[type] = new RegExp(/(^(?:.|\r|\n)*?)/.source + $.expr.match[type].source.replace(/\\(\d+)/g, function(all, num){
-          return "\\" + (num - 0 + 1);
-      }));
-  }
-}
-
-
+var setExprMatchRegex = (jquery_gt_18) ? function(type,regex) {
+		$.expr.match[type] = regex;
+	} : function(type,regex) {
+	  $.expr.match[type] = new RegExp(regex.source + /(?![^\[]*\])(?![^\(]*\))/.source);
+	  if($.expr.leftMatch) {
+	      $.expr.leftMatch[type] = new RegExp(/(^(?:.|\r|\n)*?)/.source + $.expr.match[type].source.replace(/\\(\d+)/g, function(all, num){
+	          return "\\" + (num - 0 + 1);
+	      }));
+	  }
+	};
 
 //  Modify the TAG match regexp to include optional namespace selector.
 //  This is basically (namespace|)?(tagname).
 //
-setExprMatchRegex("TAG",/^((?:((?:\\.|[-\w*]|[^\x00-\xa0])+\|)?((?:\\.|[-\w*]|[^\x00-\xa0])+)))/);
+if (jquery_gt_18) {
+	setExprMatchRegex("TAG",/^((?:((?:\\.|[-\w*]|[^\x00-\xa0])+\|)?((?:\\.|[-\w*]|[^\x00-\xa0])+)))/);
+} else {
+	setExprMatchRegex("TAG",/^((?:((?:[\w\u00c0-\uFFFF\*_-]*\|)?)((?:[\w\u00c0-\uFFFF\*_-]|\\.)+)))/);
+}
 
 //  Perform some capability-testing.
 //
@@ -203,11 +208,14 @@ if(div.localName && div.localName == "div") {
 //
 div = null;
 
-//Sizzle.selectors.match.NAME = RegExp
-//Sizzle.selectors.find.NAME = function( match, context, isXML ) {}
 //  Modify the TAG find function to account for a namespace selector.
 //
 $.expr.find.TAG = function(match,context,isXML) {
+	if (!jQuery.isArray(match)) {
+		if ( typeof context.getElementsByTagName !== "undefined" ) {
+			return context.getElementsByTagName(match);
+		}
+	}
     var ns = getNamespaceURI(match[2]);
     var ln = match[3];
     var res;
@@ -287,7 +295,7 @@ $.expr.preFilter.TAG = function(match, curLoop, inplace, result, not, isXML) {
   return [match[0],getNamespaceURI(match[2]),ln];
 };
 
-$.expr.filter.TAG = function(ns, ln) {
+function filter_tag(ns, ln) {
     return function( elem ) {
     	var e_ns = elem.namespaceURI ? elem.namespaceURI : elem.tagUrn;
         var e_ln = elem.localName ? elem.localName : elem.tagName;
@@ -299,29 +307,27 @@ $.expr.filter.TAG = function(ns, ln) {
 	};
 };
 
-//  Modify the TAG filter function to account for a namespace selector.
+//Modify the TAG filter function to account for a namespace selector.
 //
-/*$.expr.filter.TAG = function(elem,match) {
-    var ns = match[1];
+$.expr.filter.TAG = (jquery_gt_18)? filter_tag : function(elem, match) {
+	var ns = match[1];
     var ln = match[2];
-    var e_ns = elem.namespaceURI ? elem.namespaceURI : elem.tagUrn;
-    var e_ln = elem.localName ? elem.localName : elem.tagName;
-    if(ns == "*" || e_ns == ns || (ns == "" && !e_ns)) {
-        return ((ln == "*" && elem.nodeType == 1)  || e_ln == ln);
-    }
-    return false;
-};*/
-
+    return filter_tag(ns, ln).call(this, elem, null);
+};
 
 //  Modify the ATTR match regexp to extract a namespace selector.
 //  This is basically ([namespace|])(attrname)(op)(quote)(pattern)(quote)
 //
-setExprMatchRegex("ATTR",/^\[[\x20\t\r\n\f]*(((?:\\.|[-\w]|[^\x00-\xa0])+\|)?((?:\\.|[-\w]|[^\x00-\xa0])+))[\x20\t\r\n\f]*(?:([*^$|!~]?=)[\x20\t\r\n\f]*(?:(['"])((?:\\.|[^\\])*?)\5|((?:\\.|[-\w]|[^\x00-\xa0])+\|)?((?:\\.|[-\w#]|[^\x00-\xa0])+)|)|)[\x20\t\r\n\f]*\]/);
+if (jquery_gt_18) {
+	setExprMatchRegex("ATTR",/^\[[\x20\t\r\n\f]*(((?:\\.|[-\w]|[^\x00-\xa0])+\|)?((?:\\.|[-\w]|[^\x00-\xa0])+))[\x20\t\r\n\f]*(?:([*^$|!~]?=)[\x20\t\r\n\f]*(?:(['"])((?:\\.|[^\\])*?)\5|((?:\\.|[-\w]|[^\x00-\xa0])+\|)?((?:\\.|[-\w#]|[^\x00-\xa0])+)|)|)[\x20\t\r\n\f]*\]/);
+} else {
+	setExprMatchRegex("ATTR",/\[\s*((?:((?:[\w\u00c0-\uFFFF\*_-]*\|)?)((?:[\w\u00c0-\uFFFF_-]|\\.)+)))\s*(?:(\S?=)\s*(['"]*)(.*?)\5|)\s*\]/);
+}
 
 //  Modify the ATTR preFilter function to account for new regexp match groups,
 //  and normalise the namespace URI.
 //
-$.expr.preFilter.ATTR = function( match, context, isXml ) {
+$.expr.preFilter.ATTR = (jquery_gt_18)? function( match, context, isXml ) {
 	var name = match[1].replace(rbackslash, "");
 	
 	if( match[4] == "~=" ) {
@@ -338,14 +344,25 @@ $.expr.preFilter.ATTR = function( match, context, isXml ) {
     }
 	
 	return match.slice( 0, 6 );
+} : function(match, curLoop, inplace, result, not, isXML) {
+    var name = match[3].replace(/\\/g, "");
+    if(!isXML && $.expr.attrMap[name]) {
+        match[3] = $.expr.attrMap[name];
+    }
+    if( match[4] == "~=" ) {
+        match[6] = " " + match[6] + " ";
+    }
+    if(!match[2] || match[2] == "|") {
+        match[2] = "";
+    } else {
+        match[2] = getNamespaceURI(match[2]);
+    }
+    return match;
 };
 
 
-//  Modify the ATTR filter function to account for namespace selector.
-//  Unfortunately this means factoring out the attribute-checking code
-//  into a separate function, since it might be called multiple times.
-//
-var filter_attr = function(result, operator, check) {
+
+var attr_op_eval = function(result, operator, check) {
 	if ( result == null ) {
 		return operator === "!=";
 	}
@@ -364,43 +381,20 @@ var filter_attr = function(result, operator, check) {
 		operator === "~=" ? ( " " + result + " " ).indexOf( check ) > -1 :
 		operator === "|=" ? result === check || result.substr( 0, check.length + 1 ) === check + "-" :
 		false;
-}
+};
 
-
-/*$.expr.filter.ATTR = function( prefixedName, ns, name, op, value ) {//name, operator, check ) {
-	return function( elem, context ) {
-		var result = Sizzle.attr( elem, name );
-
-		if ( result == null ) {
-			return operator === "!=";
-		}
-		if ( !operator ) {
-			return true;
-		}
-
-		result += "";
-
-		return operator === "=" ? result === check :
-			operator === "!=" ? result !== check :
-			operator === "^=" ? check && result.indexOf( check ) === 0 :
-			operator === "*=" ? check && result.indexOf( check ) > -1 :
-			operator === "$=" ? check && result.substr( result.length - check.length ) === check :
-			operator === "~=" ? ( " " + result + " " ).indexOf( check ) > -1 :
-			operator === "|=" ? result === check || result.substr( 0, check.length + 1 ) === check + "-" :
-			false;
-	};
-}*/
-
-$.expr.filter.ATTR = function( prefixedName, ns, name, op, check ) {
+//Modify the ATTR filter function to account for namespace selector.
+//Unfortunately this means factoring out the attribute-checking code
+//into a separate function, since it might be called multiple times.
+//
+function filter_attr( prefixedName, ns, name, op, check ) {
 	return function( elem, context ) {
 		if(ns == "") {
 			var result = $(elem).attr(name);
-			if (filter_attr(result, op, check)) {
-                return true;
-            }
+            return attr_op_eval(result, op, check);
 		} else {
 			if(ns != "*" && typeof elem.getAttributeNS != "undefined") {
-		        return filter_attr(elem.getAttributeNS(ns,name), op, check);
+		        return attr_op_eval(elem.getAttributeNS(ns,name), op, check);
 		    }
 			
 			//  Need to iterate over all attributes, either because we couldn't
@@ -418,13 +412,13 @@ $.expr.filter.ATTR = function( prefixedName, ns, name, op, check ) {
 		        if(ln == name) {
 		            result = attrs[i].nodeValue;
 		            if(ns == "*" || attrs[i].namespaceURI == ns) {
-		                if(filter_attr(result, op, check)) {
+		                if(attr_op_eval(result, op, check)) {
 		                    return true;
 		                }
 		            }
 		            if(attrs[i].namespaceURI === "" && attrs[i].prefix) {
 		                if(attrs[i].prefix == default_xmlns_rev[ns]) {
-		                    if(filter_attr(result, op, check)) {
+		                    if(attr_op_eval(result, op, check)) {
 		                        return true;
 		                    }
 		                }
@@ -434,57 +428,15 @@ $.expr.filter.ATTR = function( prefixedName, ns, name, op, check ) {
 		    return false;
 		}
 	};
-}
+};
 
-/*$.expr.filter.ATTR = function(elem, match) {
-    var ns = match[2];
+$.expr.filter.ATTR = (jquery_gt_18)? filter_attr : function(elem, match) {
+	var ns = match[2];
     var name = match[3];
     var type = match[4];
-    var check = match[5];
-    var result;
-    //  No namespace, just use ordinary attribute lookup.
-    if(ns == "") {
-        result = $.expr.attrHandle[name] ?
-                     $.expr.attrHandle[name](elem) :
-                     elem[name] != null ?
-                         elem[name] :
-                         elem.getAttribute(name);
-        return filter_attr(result,type,check);
-    }
-    //  Directly use getAttributeNS if applicable and available
-    if(ns != "*" && typeof elem.getAttributeNS != "undefined") {
-        return filter_attr(elem.getAttributeNS(ns,name),type,check);
-    }
-    //  Need to iterate over all attributes, either because we couldn't
-    //  look it up or because we need to match all namespaces.
-    var attrs = elem.attributes;
-    for(var i=0; attrs[i]; i++) {
-        var ln = attrs[i].localName;
-        if(!ln) {
-            ln = attrs[i].nodeName;
-            var idx = ln.indexOf(":");
-            if(idx >= 0) {
-                ln = ln.substr(idx+1);
-            }
-        }
-        if(ln == name) {
-            result = attrs[i].nodeValue;
-            if(ns == "*" || attrs[i].namespaceURI == ns) {
-                if(filter_attr(result,type,check)) {
-                    return true;
-                }
-            }
-            if(attrs[i].namespaceURI === "" && attrs[i].prefix) {
-                if(attrs[i].prefix == default_xmlns_rev[ns]) {
-                    if(filter_attr(result,type,check)) {
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-    return false;
-};*/
+    var check = match[6];
+    return filter_attr(null, ns, name, type, check).call(this, elem, null);
+};
 
 
 })(jQuery);


### PR DESCRIPTION
Portions of Sizzle were rewritten in jquery 1.8, which resulted in the selector overrides no longer fitting the expectations of the API.  This pull should get it functional again in 1.8, while retaining the original code for jquery < 1.8.
